### PR TITLE
Fix/invitation link

### DIFF
--- a/app/Http/Controllers/InvitationLinkController.php
+++ b/app/Http/Controllers/InvitationLinkController.php
@@ -148,11 +148,9 @@ class InvitationLinkController extends Controller
             if (is_null($existingContribution)) {
                 $save->contributors()->attach($user, ["permission" => $invitationLink->permission]);
             } else {
-                $permission = $existingContribution->permission;
+                $this->authorize('acceptDecline', $existingContribution);
 
-                if ($existingContribution->revoked) {
-                    return \response(null, Response::HTTP_CONFLICT);
-                }
+                $permission = $existingContribution->permission;
 
                 $existingContribution->accept();
                 // check if new permission is equal or higher than old permission

--- a/app/Http/Controllers/InvitationLinkController.php
+++ b/app/Http/Controllers/InvitationLinkController.php
@@ -154,11 +154,7 @@ class InvitationLinkController extends Controller
                     return \response(null, Response::HTTP_CONFLICT);
                 }
 
-                if($existingContribution->declined){
-                    $existingContribution->declined = false;
-                    $existingContribution->accepted = true;
-                }
-
+                $existingContribution->accept();
                 // check if new permission is equal or higher than old permission
                 if (PermissionHelper::isAtLeastPermission($permission, $invitationLink->permission)) {
                     $existingContribution->permission = $permission;

--- a/app/Http/Controllers/InvitationLinkController.php
+++ b/app/Http/Controllers/InvitationLinkController.php
@@ -48,7 +48,7 @@ class InvitationLinkController extends Controller
     public function store(Request $request, TokenService $tokenService): \Illuminate\Http\RedirectResponse
     {
         $validate = $request->validate([
-            "expiry_date" => "nullable|required|date",
+            "expiry_date" => "nullable|date",
             "permission" => "required|numeric|min:0|max:1",
             "save_id" => "required|exists:saves,id"
         ]);

--- a/app/Http/Controllers/InvitationLinkController.php
+++ b/app/Http/Controllers/InvitationLinkController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Helper\PermissionHelper;
 use App\Http\Resources\InvitationLinkResource;
 use App\Models\InvitationLink;
 use App\Models\Save;
@@ -39,15 +40,15 @@ class InvitationLinkController extends Controller
      * Erstellt eine neue InvitationLink Instanz
      * @param Request $request Die aktuelle Request instanz
      * @param TokenService $tokenService Dependency Injection
-     * @return Response Code 201 mit Location Header beim erfolgreichen Anlegen der Resource
+     * @return \Illuminate\Http\RedirectResponse Code 201 mit Location Header beim erfolgreichen Anlegen der Resource
      * @throws AuthorizationException Wenn der User keine Berechtigung hat für den Speicherstand ein Einladungslink zu erstellen
      * @see InvitationLink
      * @see InvitationLinkPolicy
      */
-    public function store(Request $request, TokenService $tokenService): Response
+    public function store(Request $request, TokenService $tokenService): \Illuminate\Http\RedirectResponse
     {
         $validate = $request->validate([
-            "expiry_date" => "required|date",
+            "expiry_date" => "nullable|required|date",
             "permission" => "required|numeric|min:0|max:1",
             "save_id" => "required|exists:saves,id"
         ]);
@@ -59,7 +60,7 @@ class InvitationLinkController extends Controller
         $invitation_link->save_id = $validate["save_id"];
         $invitation_link->token = $tokenService->createToken();
         $invitation_link->save();
-        return response()->created('invitation_link', $invitation_link);
+        return response()->redirectToRoute('invitation-link.show', ['invitation_link' => $invitation_link->token]);
     }
 
     /**
@@ -95,7 +96,7 @@ class InvitationLinkController extends Controller
         $this->authorize("update", $invitation_link);
 
         $validate = $request->validate([
-            "expiry_date" => "date",
+            "expiry_date" => "nullable|date",
             "permission" => "numeric|min:0|max:1"
         ]);
 
@@ -138,11 +139,32 @@ class InvitationLinkController extends Controller
         $user = $request->user();
         $invitationLink = InvitationLink::whereToken($token)->firstOrFail();
 
-        if (Carbon::now() < $invitationLink->expiry_date) {
+        if (is_null($invitationLink->expiry_date) || Carbon::now() < $invitationLink->expiry_date) {
 
             $save = $invitationLink->safe;
 
-            $save->contributors()->attach($user, ["permission" => $invitationLink->permission]);
+            $existingContribution = $save->sharedSaves()->where('user_id', '=', $user->id)->first();
+
+            if (is_null($existingContribution)) {
+                $save->contributors()->attach($user, ["permission" => $invitationLink->permission]);
+            } else {
+                $permission = $existingContribution->permission;
+
+                if ($existingContribution->revoked) {
+                    return \response(null, Response::HTTP_CONFLICT);
+                }
+
+                if($existingContribution->declined){
+                    $existingContribution->declined = false;
+                    $existingContribution->accepted = true;
+                }
+
+                // check if new permission is equal or higher than old permission
+                if (PermissionHelper::isAtLeastPermission($permission, $invitationLink->permission)) {
+                    $existingContribution->permission = $permission;
+                    $existingContribution->save();
+                }
+            }
 
             return response()->noContent(Response::HTTP_OK);
         } else {

--- a/app/Http/Controllers/SharedSaveController.php
+++ b/app/Http/Controllers/SharedSaveController.php
@@ -148,8 +148,7 @@ class SharedSaveController extends Controller
     {
         $this->authorize("acceptDecline", $sharedSave);
         if (!$sharedSave->revoked) {
-            $sharedSave->declined = false;
-            $sharedSave->accepted = true;
+            $sharedSave->accept();
             $sharedSave->save();
             return \response()->noContent(Response::HTTP_OK);
         } else {
@@ -170,8 +169,7 @@ class SharedSaveController extends Controller
     public function decline(Request $request, SharedSave $sharedSave)
     {
         $this->authorize("acceptDecline", $sharedSave);
-        $sharedSave->accepted = false;
-        $sharedSave->declined = true;
+        $sharedSave->decline();
         $sharedSave->save();
         return \response(null, Response::HTTP_OK);
     }

--- a/app/Http/Resources/InvitationLinkResource.php
+++ b/app/Http/Resources/InvitationLinkResource.php
@@ -4,8 +4,10 @@
 namespace App\Http\Resources;
 
 
+use App\Helper\PermissionHelper;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * Klasse, welche eine InvitationLink instanz in ein Array umwandelt
@@ -21,11 +23,11 @@ class InvitationLinkResource extends JsonResource
     public function toArray($request)
     {
         return [
-            "id" => $this->id,
             "expiry_date" => $this->expiry_date,
             "permission" => $this->permission,
             "save_id" => $this->save_id,
             "created_at" => $this->created_at,
+            "token" => $this->when($this->safe->hasAtLeasPermission(Auth::user(), PermissionHelper::$PERMISSION_ADMIN), $this->token)
         ];
     }
 }

--- a/app/Models/InvitationLink.php
+++ b/app/Models/InvitationLink.php
@@ -13,8 +13,7 @@ use Illuminate\Support\Carbon;
 /**
  * App\Models\InvitationLink
  *
- * @property int $id id des Eintrags
- * @property Carbon $expiry_date Zeitpunkt an dem der Link abläuft
+ * @property Carbon|null $expiry_date Zeitpunkt an dem der Link abläuft
  * @property int $permission Rechte die ein User kriegt, wenn er mit dem Link auf den Speicherstand zugreift
  * @property int $save_id id des zugehörigen Speicherstands
  * @property string $token Token des Einladungslinks
@@ -35,7 +34,14 @@ use Illuminate\Support\Carbon;
  */
 class InvitationLink extends Model
 {
-    use HasFactory,Limitable;
+    use HasFactory, Limitable;
+
+
+    protected $primaryKey = "token";
+
+    protected $keyType = "string";
+
+    public $incrementing = false;
 
     /**
      * Attribute, welche Massen zuweisbar sind

--- a/app/Models/SharedSave.php
+++ b/app/Models/SharedSave.php
@@ -71,4 +71,16 @@ class SharedSave extends Pivot
         return $this->belongsTo(Save::class, "save_id");
     }
 
+    public function accept()
+    {
+        $this->accepted = true;
+        $this->declined = false;
+    }
+
+    public function decline()
+    {
+        $this->accepted = false;
+        $this->declined = true;
+    }
+
 }

--- a/app/Policies/InvitationLinkPolicy.php
+++ b/app/Policies/InvitationLinkPolicy.php
@@ -33,7 +33,8 @@ class InvitationLinkPolicy
      */
     public function view(User $user, InvitationLink $invitationLink): bool
     {
-        return true;
+        $shared_save = $invitationLink->safe->sharedSaves()->where('user_id', $user->id)->first();
+        return is_null($shared_save) || !$shared_save->revoked;
     }
 
     /**

--- a/app/Policies/SharedSavePolicy.php
+++ b/app/Policies/SharedSavePolicy.php
@@ -94,7 +94,7 @@ class SharedSavePolicy
      */
     public function acceptDecline(User $user, SharedSave $sharedSave): bool
     {
-        return $sharedSave->user_id === $user->id;
+        return $sharedSave->user_id === $user->id && !$sharedSave->revoked;
     }
 
     /**

--- a/database/migrations/2021_06_23_164713_create_invitation_links_table.php
+++ b/database/migrations/2021_06_23_164713_create_invitation_links_table.php
@@ -14,8 +14,9 @@ class CreateInvitationLinksTable extends Migration
     public function up()
     {
         Schema::create('invitation_links', function (Blueprint $table) {
-            $table->id();
             $table->string("token")->unique()->index();
+            $table->primary("token");
+
             $table->timestamp("expiry_date")->nullable();
             $table->integer("permission");
             $table->foreignId("save_id")->constrained(); // onDelete and onUpdate added in `add_on_delete_cascade` migration

--- a/routes/api.php
+++ b/routes/api.php
@@ -44,7 +44,7 @@ Route::group(["middleware" => ["auth:api", "activityLog"]], function () {
         "invitation-link" => InvitationLinkController::class,
     ]);
 
-    Route::apiResource('settings', SettingController::class)->only(["index","show"]);
+    Route::apiResource('settings', SettingController::class)->only(["index", "show"]);
 
     Route::apiResource('users.settings', UserSettingController::class);
 
@@ -64,13 +64,13 @@ Route::group(["middleware" => ["auth:api", "activityLog"]], function () {
 
 
     // Users
-    Route::get('users/{user}/saves', [\App\Http\Controllers\UserSavesController::class,'index']);
+    Route::get('users/{user}/saves', [\App\Http\Controllers\UserSavesController::class, 'index']);
 
     Route::apiResource('users', UserController::class)->except('store');
 
     // InvitationLink
     Route::get('saves/{save}/invitation-links', [InvitationLinkController::class, "saveIndex"]);
-    Route::get('invitation-link/{token}/accept', 'App\Http\Controllers\InvitationLinkController@acceptInvite');
+    Route::put('invitation-link/{token}/accept', [InvitationLinkController::class, "acceptInvite"]);
 
 
 });


### PR DESCRIPTION
fixes the invitaion link behaviour:

- replaced the id with the token. As a result all api routes need the token instead of the id
- new returns the after creating the invitaion link
- Included the token for every user with at least admin permissions
- enabled unlimited invitaion links by allowing to pass null as an expiry_date
- fixed accept and revoked functionality