### PR TITLE
added permission to save resource. 

### DIFF
--- a/app/Http/Controllers/SaveController.php
+++ b/app/Http/Controllers/SaveController.php
@@ -13,7 +13,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Auth;
 
 /**
  * Controller, welcher Routen zum Verwalten von Speicherständen implementiert

--- a/app/Http/Controllers/SharedSaveController.php
+++ b/app/Http/Controllers/SharedSaveController.php
@@ -125,7 +125,7 @@ class SharedSaveController extends Controller
     {
         $this->authorize("update", $sharedSave);
         $validated = $request->validate([
-            "permission" => ["integer", "min:0", "min:2"],
+            "permission" => ["integer", "min:0", "max:2"],
             "revoked" => ["boolean"],
         ]);
         $sharedSave->fill($validated);

--- a/app/Http/Resources/InvitationLinkResource.php
+++ b/app/Http/Resources/InvitationLinkResource.php
@@ -23,10 +23,9 @@ class InvitationLinkResource extends JsonResource
     public function toArray($request)
     {
         return [
+            $this->merge(new PermissionResource($this->resource)),
             "expiry_date" => $this->expiry_date,
-            "permission" => $this->permission,
             "save" => new SimplerSaveResource($this->safe),
-            "created_at" => $this->created_at,
             "token" => $this->when($this->safe->hasAtLeasPermission(Auth::user(), PermissionHelper::$PERMISSION_ADMIN), $this->token)
         ];
     }

--- a/app/Http/Resources/PermissionResource.php
+++ b/app/Http/Resources/PermissionResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PermissionResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            "permission" => $this->permission,
+            "created_at" => $this->created_at
+        ];
+    }
+}

--- a/app/Http/Resources/SaveResource.php
+++ b/app/Http/Resources/SaveResource.php
@@ -18,15 +18,11 @@ class SaveResource extends JsonResource
      */
     public function toArray($request)
     {
-        $simpleResource = new SimpleSaveResource($this->resource);
-        return array_merge_recursive($simpleResource->toArray($request), [
+        return [
+            $this->merge(new SimpleSaveResource($this->resource)),
             "data" => $this->data,
-            "contributors" => $this->contributors->map(function ($c) {
-                return new SimplestUserResource($c);
-            })->toArray(),
-            "invited" => $this->invited->map(function ($c) {
-                return new SimplestUserResource($c);
-            })->toArray(),
-        ]);
+            "contributors" => SimplestUserResource::collection($this->contributors),
+            "invited" => SimplestUserResource::collection($this->invited),
+        ];
     }
 }

--- a/app/Http/Resources/SharedSaveResource.php
+++ b/app/Http/Resources/SharedSaveResource.php
@@ -25,10 +25,10 @@ class SharedSaveResource extends JsonResource
             "id" => $this->id,
             "user" => new SimplestUserResource($this->user),
             "save" => new SimplerSaveResource($this->safe),
-            "permission" => $this->permission,
             "accepted" => $this->accepted,
             "declined" => $this->declined,
-            "revoked" => $this->revoked
+            "revoked" => $this->revoked,
+            $this->merge(new PermissionResource($this->resource)),
         ];
     }
 }

--- a/app/Http/Resources/SharedSaveUserResource.php
+++ b/app/Http/Resources/SharedSaveUserResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+
 /**
  * Klasse, welche eine Beziehung von einem Speicherstand zu einem User darstellt.
  *
@@ -22,8 +23,8 @@ class SharedSaveUserResource extends JsonResource
     public function toArray($request)
     {
         return [
-            "save_id" => $this->id,
-            "permission" => $this->pivot->permission,
+            "save" => new SimplerSaveResource($this->resource),
+            $this->merge(new PermissionResource($this->pivot))
         ];
     }
 }

--- a/app/Http/Resources/SimpleSaveResource.php
+++ b/app/Http/Resources/SimpleSaveResource.php
@@ -30,6 +30,9 @@ class SimpleSaveResource extends JsonResource
             "owner" => new SimplestUserResource($this->owner),
             "owner_deleting" => $this->owner->trashed(),
             "tool_id" => $this->tool_id,
+            "permission" => $this->whenPivotLoaded('shared_save', function () {
+                return new PermissionResource($this->pivot);
+            }),
             "updated_at" => $this->updated_at,
             "created_at" => $this->created_at,
             /*"contributors" => $this->contributors->map(function ($c) {

--- a/app/Models/Save.php
+++ b/app/Models/Save.php
@@ -68,7 +68,7 @@ use Illuminate\Support\Carbon;
  */
 class Save extends Model
 {
-    use HasFactory, SoftDeletes,Limitable;
+    use HasFactory, SoftDeletes, Limitable;
 
     /**
      * Attribute, welche Massen zuweisbar sind
@@ -147,7 +147,7 @@ class Save extends Model
         return $this->belongsToMany(User::class, 'shared_save')->using(SharedSave::class)
             ->withPivot(["permission", "accepted", "declined", "revoked"])
             ->withPivotValue("accepted", false)
-            ->withPivotValue("revoked",false)
+            ->withPivotValue("revoked", false)
             ->withTimestamps();
     }
 
@@ -187,6 +187,12 @@ class Save extends Model
             ->withTimestamps();
     }
 
+    public function isContributor(User|int $user)
+    {
+        $id = is_int($user) ? $user : $user->id;
+        return $this->contributors->firstWhere('id', $id) !== null;
+    }
+
     /**
      * Prüft, ob der übergebene User mindestens die angegebene Berechtigung bei diesem Speicherstand besitzt
      * @param User $user Der zu überprüfende User
@@ -197,7 +203,7 @@ class Save extends Model
     {
         if ($user->id === $this->owner_id) {
             return true;
-        } else if (($contributor = $this->contributors()->firstWhere('user_id', '=', $user->id)) !== null) {
+        } else if (($contributor = $this->contributors->firstWhere('id', '=', $user->id)) !== null) {
             $hasPermission = $contributor->pivot->permission;
             if (PermissionHelper::isAtLeastPermission($hasPermission, $permission)) {
                 return true;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -195,7 +195,7 @@ class User extends Authenticatable
      * @param bool $withPivot Ob die Pivot Tabelle mitgeladen werden soll
      * @return BelongsToMany
      */
-    public function accessibleShares(bool $withPivot = true): BelongsToMany
+    public function accessibleShares(bool|array $withPivot = true): BelongsToMany
     {
         $q = $this->belongsToMany(Save::class, 'shared_save')->using(SharedSave::class)
             ->withPivotValue("accepted", true)
@@ -215,15 +215,16 @@ class User extends Authenticatable
 
     public function settings($setting_id = -1): BelongsToMany
     {
-        $q = $this->belongsToMany(Setting::class, 'user_settings')->withPivot(['id','value']);
-        if($setting_id !== -1){
-            $q->where('setting_id' , $setting_id);
+        $q = $this->belongsToMany(Setting::class, 'user_settings')->withPivot(['id', 'value']);
+        if ($setting_id !== -1) {
+            $q->where('setting_id', $setting_id);
         }
 
         return $q;
     }
 
-    public function getSetting($setting_id){
+    public function getSetting($setting_id)
+    {
         return $this->hasMany(UserSetting::class);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -195,7 +195,7 @@ class User extends Authenticatable
      * @param bool $withPivot Ob die Pivot Tabelle mitgeladen werden soll
      * @return BelongsToMany
      */
-    public function accessibleShares(bool|array $withPivot = true): BelongsToMany
+    public function accessibleShares(bool $withPivot = true): BelongsToMany
     {
         $q = $this->belongsToMany(Save::class, 'shared_save')->using(SharedSave::class)
             ->withPivotValue("accepted", true)


### PR DESCRIPTION
The save show and user showSaves route now returns the permission with every save which isn't owned by the authenticated user. 

BREAKING CHANGES:

UserResource -> now returns save with tool and user data instead of save_id in invited and shared save